### PR TITLE
Add sample configuration files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DATABASE_URL=postgresql://app_user:user@localhost:5432/sensor_db
+MQTT_URL=mqtt://localhost:1883
+PORT=4000
+YANDEX_MAPS_APIKEY=YOUR_MAPS_API_KEY
+ACCESS_CODES_PATH=config/access-codes.json

--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ sudo docker compose up -d        # создаст web, db, mqtt
 | Файл | Назначение |
 |------|------------|
 | **.env** | Единая точка настройки: `DATABASE_URL`, `MQTT_URL`, `PORT`, `YANDEX_MAPS_APIKEY`, `ACCESS_CODES_PATH` |
+| **.env.example** | Пример значений для переменных окружения |
 | **config/access-codes.json** | Одноразовые коды авторизации. Добавляйте новые, задавая `role = admin / user`. |
+| **config/access-codes.json.example** | Пример файла кодов авторизации |
 | **config/mosquitto.conf** | Пример безопасной (password‑file) конфигурации брокера. |
 
 **Совет для продакшна:** отключите `allow_anonymous true` в Mosquitto и включите TLS.

--- a/config/access-codes.json.example
+++ b/config/access-codes.json.example
@@ -1,0 +1,6 @@
+{
+    "codes": [
+        {"code": "ADMIN-CODE-123", "role": "admin"},
+        {"code": "USER-CODE-456", "role": "user"}
+    ]
+}


### PR DESCRIPTION
## Summary
- provide `.env.example` with placeholder values
- include `config/access-codes.json.example`
- document example files in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bffc991348326b4538249f4767044