### PR TITLE
Remove interactive cleanup prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ npm run db:init                  # создаст БД, таблицы, расш
 
 # 9. Запуск
 npm run start:prod               # или: node index.js
+# при необходимости очистить таблицы перед стартом:
+# CLEAR_TABLES=true node index.js  # либо: node index.js --clear
 ```
 
 Через пару секунд фронтенд будет доступен на `http://<IP‑платы>:4000`  (порт задаётся переменной `PORT`).


### PR DESCRIPTION
## Summary
- drop readline usage and start the server immediately
- make table cleanup optional via `--clear` or `CLEAR_TABLES=true`
- document the new option in the Quick Start guide

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bffc90bac8326b849d0ec7ab532f1