### PR TITLE
Add DB init script and prod start command

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "server": "node index.js",
-    "mqtt": "node mqttSimulator.js"
+    "mqtt": "node mqttSimulator.js",
+    "db:init": "node scripts/db-init.js",
+    "start:prod": "NODE_ENV=production node index.js"
   },
   "author": "",
   "license": "ISC",

--- a/scripts/db-init.js
+++ b/scripts/db-init.js
@@ -1,0 +1,39 @@
+const { Client } = require('pg');
+
+const client = new Client({
+    user: 'app_user',
+    host: 'localhost',
+    database: 'sensor_db',
+    password: 'user',
+    port: 5432,
+});
+
+const sql = `
+CREATE TABLE IF NOT EXISTS sensors (
+    id TEXT PRIMARY KEY,
+    type TEXT,
+    name TEXT,
+    lat DOUBLE PRECISION,
+    lng DOUBLE PRECISION
+);
+CREATE TABLE IF NOT EXISTS sensor_history (
+    sensor_id TEXT REFERENCES sensors(id) ON DELETE CASCADE,
+    time TIMESTAMP,
+    data TEXT,
+    PRIMARY KEY (sensor_id, time)
+);
+`;
+
+async function init() {
+    try {
+        await client.connect();
+        await client.query(sql);
+        console.log('Database initialized');
+    } catch (err) {
+        console.error('Failed to initialize database:', err);
+    } finally {
+        await client.end();
+    }
+}
+
+init();


### PR DESCRIPTION
## Summary
- create `scripts/db-init.js` to initialise PostgreSQL tables
- expose `db:init` and `start:prod` npm scripts

## Testing
- `npm run db:init` *(fails: no running PostgreSQL)*

------
https://chatgpt.com/codex/tasks/task_e_684bff44ea948326a206a9d78c14c3a1